### PR TITLE
Support return of single (or none) items instead of enforcing tuple

### DIFF
--- a/docs/source/quickstart/implementing_functions.rst
+++ b/docs/source/quickstart/implementing_functions.rst
@@ -25,7 +25,7 @@ Declare a new class and derive it from :class:`~openmnglab.functions.base.Functi
 
 
     class SeriesChooserFunc(FunctionBase):
-        def execute(self) -> Iterable[IDataContainer]:
+        def execute(self) -> IDataContainer | Iterable[IDataContainer]:
             pass
 
         def set_input(self, *data_in: IDataContainer):
@@ -69,7 +69,7 @@ We will implement the constructor and specify the type annotations of our class:
             self.series_b_container: PandasContainer[pd.Series] = None
             self.chosen_series = chosen_series
 
-        def execute(self) -> tuple[PandasContainer[pd.Series]]:
+        def execute(self) -> PandasContainer[pd.Series]:
             pass
 
         def set_input(self, series_a_container: PandasContainer[pd.Series], series_b_container: PandasContainer[pd.Series]):
@@ -79,11 +79,7 @@ We will implement the constructor and specify the type annotations of our class:
 Now implement the (trivial) execution function. For the sake of demonstration, we will not simple return the chosen container, but will construct a new one with the chosen series.
 Remember that a `PandasContainer` requires a dictionary which contains the unit of each column and index of the contained pandas structure.
 
-.. important::
-    Always make sure to include a comma at the end of ``execute`` to return a tuple! Returning a single item not wrapped in a tuple is not supported at this time.
-
 .. code-block:: python
-    :emphasize-lines: 17, 18
 
     import pandas as pd
 
@@ -98,11 +94,10 @@ Remember that a `PandasContainer` requires a dictionary which contains the unit 
             self.series_b_container: PandasContainer[pd.Series] = None
             self.chosen_series = chosen_series
 
-        def execute(self) -> tuple[PandasContainer[pd.Series]]:
+        def execute(self) -> PandasContainer[pd.Series]:
             chosen_container = self.series_a_container if self.chosen_series == 0 else self.series_b_container
             return_container = PandasContainer(chosen_container.data, chosen_container.units)
-            # remember to return a tuple
-            return return_container,
+            return return_container
 
         def set_input(self, series_a_container: PandasContainer[pd.Series], series_b_container: PandasContainer[pd.Series]):
             self.series_a_container = series_a_container
@@ -112,11 +107,7 @@ Test
 ^^^^^
 You should now test your function to make sure it works like intended:
 
-.. important::::
-    Always make sure to include a comma to unpack the result of ``execute``.
-
 .. code-block:: python
-    :emphasize-lines: 19, 20
 
     import quantities as pq
 
@@ -136,7 +127,7 @@ You should now test your function to make sure it works like intended:
     # set the input
     chooser.set_input(ser_a_container, ser_b_container)
     # execute it; remember to include the comma to unpack the returned tuple
-    chosen_series_container, = chooser.execute()
+    chosen_series_container = chooser.execute()
 
     print(chosen_series_container)
 
@@ -225,7 +216,7 @@ we will also have to implement a function that will return the data schema for a
 .. code-block:: python
 
     def production_for(self, schema_a: PandasOutputDataScheme[SeriesSchema], schema_b: PandasOutputDataScheme[SeriesSchema]) -> tuple[PandasOutputDataScheme[SeriesSchema]]:
-        return schema_a if self.chosen_series == 0 else schema_b,
+        return schema_a if self.chosen_series == 0 else schema_b
 
 
 Finally, we have to implement the factory function
@@ -259,7 +250,7 @@ Complete implementation
             chosen_container = self.series_a_container if self.chosen_series == 0 else self.series_b_container
             return_container = PandasContainer(chosen_container.data, chosen_container.units)
             # remember to return a tuple
-            return return_container,
+            return return_container
 
         def set_input(self, series_a_container: PandasContainer[pd.Series], series_b_container: PandasContainer[pd.Series]):
             self.series_a_container = series_a_container
@@ -281,7 +272,7 @@ Complete implementation
 
         def production_for(self, schema_a: PandasOutputDataScheme[SeriesSchema],
                            schema_b: PandasOutputDataScheme[SeriesSchema]) -> tuple[PandasOutputDataScheme[SeriesSchema]]:
-            return schema_a if self.chosen_series == 0 else schema_b,
+            return schema_a if self.chosen_series == 0 else schema_b
 
         def new_function(self) -> SeriesChooserFunc:
             return SeriesChooserFunc(self.chosen_series)

--- a/openmnglab/execution/singlethreaded.py
+++ b/openmnglab/execution/singlethreaded.py
@@ -18,7 +18,12 @@ def _func_setinput(func: IFunction, *inp: IDataContainer):
 def _func_exec(func: IFunction) -> Iterable[IDataContainer]:
     try:
         ret = func.execute()
-        return ret if ret is not None else tuple()
+        if ret is None:
+            return tuple()
+        elif isinstance(IDataContainer, ret):
+            return (ret,)
+        else:
+            return ret
     except Exception as e:
         raise FunctionExecutionError("function failed to execute") from e
 

--- a/openmnglab/execution/singlethreaded.py
+++ b/openmnglab/execution/singlethreaded.py
@@ -20,7 +20,7 @@ def _func_exec(func: IFunction) -> Iterable[IDataContainer]:
         ret = func.execute()
         if ret is None:
             return tuple()
-        elif isinstance(IDataContainer, ret):
+        elif isinstance(ret, IDataContainer):
             return (ret,)
         else:
             return ret

--- a/openmnglab/execution/singlethreaded.py
+++ b/openmnglab/execution/singlethreaded.py
@@ -6,6 +6,7 @@ from openmnglab.model.execution.interface import IExecutor
 from openmnglab.model.functions.interface import IFunction
 from openmnglab.model.planning.interface import IProxyData
 from openmnglab.model.planning.plan.interface import IExecutionPlan, IPlannedData
+from openmnglab.util.iterables import ensure_iterable
 
 
 def _func_setinput(func: IFunction, *inp: IDataContainer):
@@ -17,13 +18,7 @@ def _func_setinput(func: IFunction, *inp: IDataContainer):
 
 def _func_exec(func: IFunction) -> Iterable[IDataContainer]:
     try:
-        ret = func.execute()
-        if ret is None:
-            return tuple()
-        elif isinstance(ret, IDataContainer):
-            return (ret,)
-        else:
-            return ret
+        return ensure_iterable(func.execute(), IDataContainer)
     except Exception as e:
         raise FunctionExecutionError("function failed to execute") from e
 

--- a/openmnglab/functions/base.py
+++ b/openmnglab/functions/base.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import Generic
 
-from openmnglab.model.functions.interface import IFunction, IFunctionDefinition, ISourceFunction, Prods, \
+from openmnglab.model.functions.interface import IFunction, IFunctionDefinition, ISourceFunction, ProxyRet, \
     IStaticFunctionDefinition, ISourceFunctionDefinition
 from openmnglab.util.hashing import Hash
 
@@ -20,7 +20,7 @@ class SourceFunctionBase(FunctionBase, ISourceFunction, ABC):
         pass
 
 
-class FunctionDefinitionBase(Generic[*Prods], IFunctionDefinition[*Prods], ABC):
+class FunctionDefinitionBase(Generic[ProxyRet], IFunctionDefinition[ProxyRet], ABC):
 
     def __init__(self, identifier: str):
         self._identifier = identifier
@@ -41,11 +41,11 @@ class FunctionDefinitionBase(Generic[*Prods], IFunctionDefinition[*Prods], ABC):
         return hashgen.digest()
 
 
-class StaticFunctionDefinitionBase(Generic[*Prods], FunctionDefinitionBase[*Prods], IStaticFunctionDefinition[*Prods],
+class StaticFunctionDefinitionBase(Generic[ProxyRet], FunctionDefinitionBase[ProxyRet], IStaticFunctionDefinition[ProxyRet],
                                    ABC):
     ...
 
 
-class SourceFunctionDefinitionBase(Generic[*Prods], StaticFunctionDefinitionBase[*Prods],
-                                   ISourceFunctionDefinition[*Prods], ABC):
+class SourceFunctionDefinitionBase(Generic[ProxyRet], StaticFunctionDefinitionBase[ProxyRet],
+                                   ISourceFunctionDefinition[ProxyRet], ABC):
     ...

--- a/openmnglab/functions/input/readers/dapsys_reader.py
+++ b/openmnglab/functions/input/readers/dapsys_reader.py
@@ -12,7 +12,7 @@ from openmnglab.model.planning.interface import IProxyData
 from openmnglab.util.hashing import Hash
 
 
-class DapsysReader(SourceFunctionDefinitionBase[IProxyData[pd.Series], IProxyData[pd.Series], IProxyData[pd.Series]]):
+class DapsysReader(SourceFunctionDefinitionBase[tuple[IProxyData[pd.Series], IProxyData[pd.Series], IProxyData[pd.Series]]]):
     """Loads data from a DAPSYS file
 
     In: nothing

--- a/openmnglab/functions/plot/funcs/waveforms.py
+++ b/openmnglab/functions/plot/funcs/waveforms.py
@@ -100,7 +100,7 @@ class WaveformPlotFunc(FunctionBase):
             return self._plot_rel(**universal_kwargs)
         return self._plot_line(**universal_kwargs)
 
-    def execute(self) -> tuple[MatPlotLibContainer]:
+    def execute(self) -> MatPlotLibContainer:
         with self.theme:
             if self.mode == WaveformPlotMode.AVERAGE:
                 fig = self._plot_avg()
@@ -108,7 +108,7 @@ class WaveformPlotFunc(FunctionBase):
                 fig = self._plot_overlap()
             else:
                 raise NotImplementedError(f"Mode {self.mode} is not implemented")
-        return MatPlotLibContainer(fig),
+        return MatPlotLibContainer(fig)
 
     def set_input(self, data: PandasContainer):
         self.data_container = data

--- a/openmnglab/functions/plot/waveforms.py
+++ b/openmnglab/functions/plot/waveforms.py
@@ -90,10 +90,10 @@ class WaveformPlot(StaticFunctionDefinitionBase[IProxyData[plt.Figure]]):
         return h.digest()
 
     @property
-    def consumes(self) -> tuple[PandasInputDataScheme[pd.DataFrame]]:
+    def consumes(self) -> PandasInputDataScheme[pd.DataFrame]:
         return PandasInputDataScheme(DataFrameSchema({
             self.column: Column(float)
-        })),
+        }))
 
     def new_function(self) -> WaveformPlotFunc:
         return WaveformPlotFunc(mode=self.mode, selector=self.selector, column=self.column, fig_args=self.fig_args,
@@ -101,5 +101,5 @@ class WaveformPlot(StaticFunctionDefinitionBase[IProxyData[plt.Figure]]):
                                 time_col=self.time_col, stim_idx=self.stim_idx, **self.sns_args)
 
     @property
-    def produces(self) -> tuple[MatPlotlibSchema]:
-        return MatPlotlibSchema(),
+    def produces(self) -> MatPlotlibSchema:
+        return MatPlotlibSchema()

--- a/openmnglab/functions/processing/funcs/interval_data.py
+++ b/openmnglab/functions/processing/funcs/interval_data.py
@@ -98,7 +98,7 @@ class IntervalDataFunc(FunctionBase):
             units[name] = u
         return units
 
-    def execute(self) -> tuple[PandasContainer[DataFrame]]:
+    def execute(self) -> PandasContainer[DataFrame]:
         intervals = self._window_intervals.data
         recording = self._recording.data
         interval_ranges = np.fromiter(
@@ -139,7 +139,7 @@ class IntervalDataFunc(FunctionBase):
                                                recording.index.name], codes=multiindex_codes)
         return PandasContainer(DataFrame(data=diffs.T,
                                          columns=[LEVEL_COLUMN[i] for i in self._levels], index=new_multiindex),
-                               units=self.build_unitdict()),
+                               units=self.build_unitdict())
 
     def set_input(self, window_intervals: IDataContainer, data: IDataContainer):
         self._window_intervals = window_intervals

--- a/openmnglab/functions/processing/funcs/spdf_features.py
+++ b/openmnglab/functions/processing/funcs/spdf_features.py
@@ -113,7 +113,7 @@ class FeatureFunc(FunctionBase):
             units[index_name] = self._components.units[index_name]
         return units
 
-    def execute(self) -> tuple[PandasContainer[DataFrame]]:
+    def execute(self) -> PandasContainer[DataFrame]:
         stuff = self._components.data.index
 
         nmpy = np.empty((len(stuff), 24), dtype=self._dtype)
@@ -123,7 +123,7 @@ class FeatureFunc(FunctionBase):
                                           *(spike_components[component] for component in PRINCIPLE_COMPONENTS))
         df = DataFrame(data=nmpy, columns=SPDF_FEATURES, index=self._components.data.index)
 
-        return PandasContainer(df, self.build_unitdict()),
+        return PandasContainer(df, self.build_unitdict())
 
     def set_input(self, components: PandasContainer[DataFrame], diffs: PandasContainer[DataFrame]) -> Self:
         self._components = components

--- a/openmnglab/functions/processing/funcs/waveform_components.py
+++ b/openmnglab/functions/processing/funcs/waveform_components.py
@@ -104,11 +104,11 @@ class WaveformComponentsFunc(FunctionBase):
             units[column_name] = self._diffs.units[self._diffs.data.index.names[-1]]
         return units
 
-    def execute(self) -> tuple[PandasContainer[DataFrame]]:
+    def execute(self) -> PandasContainer[DataFrame]:
         idx = self._diffs.data.index.droplevel(-1).unique()
         components = self.calc_principle_components()
         df = DataFrame(data=components.T, columns=PRINCIPLE_COMPONENTS, index=idx)
-        return PandasContainer(df, units=self.build_unitdict()),
+        return PandasContainer(df, units=self.build_unitdict())
 
     def set_input(self, diffs: PandasContainer[DataFrame]):
         self._diffs = diffs

--- a/openmnglab/functions/processing/funcs/windowing.py
+++ b/openmnglab/functions/processing/funcs/windowing.py
@@ -21,7 +21,7 @@ class WindowingFunc(FunctionBase):
         self._closed = closed
         self._name = name
 
-    def execute(self) -> Tuple[PandasContainer[Series]]:
+    def execute(self) -> PandasContainer[Series]:
         origin_series = self._target_series_container.data
         series_quantity = self._target_series_container.units[origin_series.name]
         lo, hi = magnitudes(*rescale_pq(series_quantity, self._lo, self._hi))
@@ -33,7 +33,7 @@ class WindowingFunc(FunctionBase):
         window_series.name = self._name
         q_dict = get_index_quantities(self._target_series_container)
         q_dict[window_series.name] = series_quantity
-        return PandasContainer(window_series, q_dict),
+        return PandasContainer(window_series, q_dict)
 
     def set_input(self, series: PandasContainer[Series]):
         self._target_series_container = series

--- a/openmnglab/functions/processing/interval_data.py
+++ b/openmnglab/functions/processing/interval_data.py
@@ -151,7 +151,7 @@ class IntervalData(FunctionDefinitionBase[IProxyData[DataFrame]]):
         return generic_interval_list(), NumericIndexedList()
 
     def production_for(self, window_intervals: IOutputDataScheme[pa.SeriesSchema],
-                       data: IOutputDataScheme[pa.SeriesSchema]) -> tuple[IntervalDataOutputSchema]:
+                       data: IOutputDataScheme[pa.SeriesSchema]) -> IntervalDataOutputSchema:
         window_scheme, data_scheme = self.consumes
         assert (window_scheme.accepts(window_intervals))
         assert (data_scheme.accepts(data))
@@ -161,7 +161,7 @@ class IntervalData(FunctionDefinitionBase[IProxyData[DataFrame]]):
             idx = pa.MultiIndex([window_intervals.pandera_schema.index, data.pandera_schema.index])
         else:
             idx = pa.MultiIndex([*window_intervals.pandera_schema.index.indexes, data.pandera_schema.index])
-        return IntervalDataOutputSchema(idx, *self._levels),
+        return IntervalDataOutputSchema(idx, *self._levels)
 
     def new_function(self) -> IntervalDataFunc:
         return IntervalDataFunc(self._levels,

--- a/openmnglab/functions/processing/spdf_features.py
+++ b/openmnglab/functions/processing/spdf_features.py
@@ -39,10 +39,9 @@ class SPDFFeatures(FunctionDefinitionBase[IProxyData[DataFrame]]):
     def consumes(self) -> tuple[PrincipleComponentsInputScheme, IntervalDataInputSchema]:
         return PrincipleComponentsInputScheme(), IntervalDataInputSchema(0, 1, 2)
 
-    def production_for(self, principle_compo: PrincipleComponentsInputScheme, diffs: IntervalDataInputSchema) -> tuple[
-        SPDFFeatureOutputSchema]:
+    def production_for(self, principle_compo: PrincipleComponentsInputScheme, diffs: IntervalDataInputSchema) -> SPDFFeatureOutputSchema:
         compare_index(principle_compo.pandera_schema.index, pa.MultiIndex(diffs.pandera_schema.index.indexes[:-1]))
-        return SPDFFeatureOutputSchema(principle_compo.pandera_schema.index),
+        return SPDFFeatureOutputSchema(principle_compo.pandera_schema.index)
 
     def new_function(self) -> FeatureFunc:
         return FeatureFunc()

--- a/openmnglab/functions/processing/waveform_components.py
+++ b/openmnglab/functions/processing/waveform_components.py
@@ -44,13 +44,12 @@ class WaveformComponents(FunctionDefinitionBase[IProxyData[DataFrame]]):
         super().__init__("openmnglab.principlecomponents")
 
     @property
-    def consumes(self) -> tuple[IntervalDataInputSchema]:
-        return IntervalDataInputSchema(0, 1),
+    def consumes(self) -> IntervalDataInputSchema:
+        return IntervalDataInputSchema(0, 1)
 
     @staticmethod
-    def production_for(diffs: PandasInputDataScheme[pa.DataFrameSchema]) -> tuple[
-        PrincipleComponentsDynamicOutputScheme]:
-        return PrincipleComponentsDynamicOutputScheme(diffs.pandera_schema.index),
+    def production_for(diffs: PandasInputDataScheme[pa.DataFrameSchema]) ->  PrincipleComponentsDynamicOutputScheme:
+        return PrincipleComponentsDynamicOutputScheme(diffs.pandera_schema.index)
 
     @staticmethod
     def new_function() -> WaveformComponentsFunc:

--- a/openmnglab/functions/processing/windowing.py
+++ b/openmnglab/functions/processing/windowing.py
@@ -78,12 +78,12 @@ class Windowing(FunctionDefinitionBase[IProxyData[DataFrame]]):
             .digest()
 
     @property
-    def consumes(self) -> tuple[WindowingInputDataScheme]:
-        return WindowingInputDataScheme(),
+    def consumes(self) -> WindowingInputDataScheme:
+        return WindowingInputDataScheme()
 
-    def production_for(self, inp: PandasOutputDataScheme) -> tuple[DynamicIndexIntervalScheme]:
+    def production_for(self, inp: PandasOutputDataScheme) -> DynamicIndexIntervalScheme:
         assert isinstance(inp, PandasOutputDataScheme)
-        return DynamicIndexIntervalScheme.for_input(inp, self._name),
+        return DynamicIndexIntervalScheme.for_input(inp, self._name)
 
     def new_function(self) -> IFunction:
         return WindowingFunc(self._lo, self._hi, self._name, closed=self._closed)

--- a/openmnglab/model/functions/interface.py
+++ b/openmnglab/model/functions/interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Iterable, Sequence, Literal, TypeVarTuple, Generic
+from typing import Optional, Iterable, Sequence, Literal, TypeVarTuple, Generic, TypeVar
 
 from openmnglab.model.datamodel.interface import IDataContainer, IInputDataScheme, IOutputDataScheme
 
@@ -43,10 +43,10 @@ class ISourceFunction(IFunction, ABC):
         ...
 
 
-Prods = TypeVarTuple('Prods')
+ProxyRet = TypeVar('ProxyRet')
 
 
-class IFunctionDefinition(ABC, Generic[*Prods]):
+class IFunctionDefinition(ABC, Generic[ProxyRet]):
 
     @property
     @abstractmethod
@@ -77,7 +77,7 @@ class IFunctionDefinition(ABC, Generic[*Prods]):
         ...
 
 
-class IStaticFunctionDefinition(Generic[*Prods], IFunctionDefinition[*Prods], ABC):
+class IStaticFunctionDefinition(Generic[ProxyRet], IFunctionDefinition[ProxyRet], ABC):
     @property
     @abstractmethod
     def produces(self) -> Optional[Sequence[IOutputDataScheme] | IOutputDataScheme]:
@@ -87,7 +87,7 @@ class IStaticFunctionDefinition(Generic[*Prods], IFunctionDefinition[*Prods], AB
         return self.produces
 
 
-class ISourceFunctionDefinition(Generic[*Prods], IStaticFunctionDefinition[*Prods], ABC):
+class ISourceFunctionDefinition(Generic[ProxyRet], IStaticFunctionDefinition[ProxyRet], ABC):
 
     @property
     def consumes(self) -> Literal[None]:

--- a/openmnglab/model/functions/interface.py
+++ b/openmnglab/model/functions/interface.py
@@ -16,7 +16,7 @@ class IFunction(ABC):
     """
 
     @abstractmethod
-    def execute(self) -> Optional[Iterable[IDataContainer]]:
+    def execute(self) -> Optional[IDataContainer, Iterable[IDataContainer]]:
         """ Execute the function based on the data set by :meth:`set_input`
 
         :return: The data containers produced by executing the function

--- a/openmnglab/model/functions/interface.py
+++ b/openmnglab/model/functions/interface.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Iterable, Sequence, Literal, TypeVarTuple, Generic, TypeVar
+from typing import Optional, Iterable, Sequence, Literal, Generic, TypeVar
 
 from openmnglab.model.datamodel.interface import IDataContainer, IInputDataScheme, IOutputDataScheme
 
@@ -16,7 +16,7 @@ class IFunction(ABC):
     """
 
     @abstractmethod
-    def execute(self) -> Optional[IDataContainer, Iterable[IDataContainer]]:
+    def execute(self) -> Optional[IDataContainer | Iterable[IDataContainer]]:
         """ Execute the function based on the data set by :meth:`set_input`
 
         :return: The data containers produced by executing the function

--- a/openmnglab/model/planning/interface.py
+++ b/openmnglab/model/planning/interface.py
@@ -4,7 +4,7 @@ from abc import abstractmethod, ABC
 from typing import Optional, TypeVar, Generic
 
 from openmnglab.model.datamodel.interface import IDataContainer
-from openmnglab.model.functions.interface import IFunctionDefinition, ISourceFunctionDefinition, Prods
+from openmnglab.model.functions.interface import IFunctionDefinition, ISourceFunctionDefinition, ProxyRet
 from openmnglab.model.planning.plan.interface import IExecutionPlan
 from openmnglab.model.shared import IHashIdentifiedElement
 
@@ -12,14 +12,13 @@ from openmnglab.model.shared import IHashIdentifiedElement
 class IExecutionPlanner(ABC):
 
     @abstractmethod
-    def add_function(self, function: IFunctionDefinition[*Prods], *inp_data: IProxyData) -> Optional[tuple[*Prods]]:
+    def add_function(self, function: IFunctionDefinition[ProxyRet], *inp_data: IProxyData) -> ProxyRet:
         ...
 
-    def add_source(self, function: ISourceFunctionDefinition[*Prods]) -> tuple[*Prods]:
+    def add_source(self, function: ISourceFunctionDefinition[ProxyRet]) -> ProxyRet:
         return self.add_function(function)
 
-    def add_stage(self, function: IFunctionDefinition[*Prods], input_0: IProxyData, *other_inputs: IProxyData) -> tuple[
-        *Prods]:
+    def add_stage(self, function: IFunctionDefinition[ProxyRet], input_0: IProxyData, *other_inputs: IProxyData) -> ProxyRet:
         return self.add_function(function, input_0, *other_inputs)
 
     @abstractmethod

--- a/openmnglab/planning/base.py
+++ b/openmnglab/planning/base.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Collection, TypeVar, Generic, Optional, Iterable, Mapping
+from typing import Collection, TypeVar, Generic, Iterable, Mapping, Sequence
 
 from openmnglab.datamodel.exceptions import DataSchemeCompatibilityError
 from openmnglab.model.datamodel.interface import IInputDataScheme, IOutputDataScheme
 from openmnglab.model.functions.interface import IFunctionDefinition, ProxyRet
-from openmnglab.planning.exceptions import InvalidFunctionArgumentCountError, FunctionArgumentSchemaError, PlanningError
 from openmnglab.model.planning.interface import IExecutionPlanner, IProxyData
 from openmnglab.model.planning.plan.interface import IExecutionPlan, IStage, IPlannedData, IPlannedElement
+from openmnglab.planning.exceptions import InvalidFunctionArgumentCountError, FunctionArgumentSchemaError, PlanningError
+from openmnglab.util.iterables import ensure_iterable, ensure_sequence
 
 
-def check_input(expected_schemes: Optional[Collection[IInputDataScheme]], actual_schemes: Optional[Collection[IOutputDataScheme]]):
-    expected_schemes: Collection[IInputDataScheme] = expected_schemes if expected_schemes is not None else tuple()
-    actual_schemes: Collection[IOutputDataScheme] = actual_schemes if actual_schemes is not None else tuple()
+def check_input(expected_schemes: Sequence[IInputDataScheme] | IInputDataScheme | None,
+                actual_schemes: Sequence[IOutputDataScheme] | IOutputDataScheme | None):
+    expected_schemes: Sequence[IInputDataScheme] = ensure_sequence(expected_schemes, IInputDataScheme)
+    actual_schemes: Sequence[IOutputDataScheme] = ensure_sequence(actual_schemes, IOutputDataScheme)
     if len(expected_schemes) != len(actual_schemes):
         raise InvalidFunctionArgumentCountError(len(expected_schemes), len(actual_schemes))
     for pos, (expected_scheme, actual_scheme) in enumerate(zip(expected_schemes, actual_schemes)):

--- a/openmnglab/planning/base.py
+++ b/openmnglab/planning/base.py
@@ -5,7 +5,7 @@ from typing import Collection, TypeVar, Generic, Optional, Iterable, Mapping
 
 from openmnglab.datamodel.exceptions import DataSchemeCompatibilityError
 from openmnglab.model.datamodel.interface import IInputDataScheme, IOutputDataScheme
-from openmnglab.model.functions.interface import IFunctionDefinition
+from openmnglab.model.functions.interface import IFunctionDefinition, ProxyRet
 from openmnglab.planning.exceptions import InvalidFunctionArgumentCountError, FunctionArgumentSchemaError, PlanningError
 from openmnglab.model.planning.interface import IExecutionPlanner, IProxyData
 from openmnglab.model.planning.plan.interface import IExecutionPlan, IStage, IPlannedData, IPlannedElement
@@ -71,12 +71,11 @@ class PlannerBase(IExecutionPlanner, ABC, Generic[_FuncT, _DataT]):
         return ExecutionPlan(self._functions.copy(), self._data.copy())
 
     @abstractmethod
-    def _add_function(self, function: IFunctionDefinition, *inp_data: _DataT) -> tuple[IProxyData, ...]:
+    def _add_function(self, function: IFunctionDefinition[ProxyRet], *inp_data: _DataT) -> ProxyRet:
         ...
 
-    def add_function(self, function: IFunctionDefinition, *inp_data: IProxyData) -> Optional[tuple[IProxyData, ...]]:
-        result = self._add_function(function, *self._proxy_data_to_concrete(*inp_data))
-        return result if len(result) > 0 else None
+    def add_function(self, function: IFunctionDefinition[ProxyRet], *inp_data: IProxyData) -> ProxyRet:
+        return self._add_function(function, *self._proxy_data_to_concrete(*inp_data))
 
     def _proxy_data_to_concrete(self, *inp_data: IProxyData) -> Iterable[_DataT]:
         for pos, inp in enumerate(inp_data):

--- a/openmnglab/planning/default.py
+++ b/openmnglab/planning/default.py
@@ -7,6 +7,7 @@ from openmnglab.planning.exceptions import PlanningError
 from openmnglab.model.planning.interface import IProxyData
 from openmnglab.model.planning.plan.interface import IStage, IPlannedData
 from openmnglab.util.hashing import Hash
+from openmnglab.util.iterables import ensure_iterable
 
 
 class Stage(IStage):
@@ -20,7 +21,7 @@ class Stage(IStage):
         self._definition = definition
         self._data_in = data_in
         self._data_out = tuple(PlannedData.from_function(self, out, i) for i, out in
-                               enumerate(definition.production_for(*(d.schema for d in data_in))))
+                               enumerate(ensure_iterable(definition.production_for(*(d.schema for d in data_in)), IOutputDataScheme)))
 
     @property
     def definition(self) -> IFunctionDefinition:

--- a/openmnglab/planning/default.py
+++ b/openmnglab/planning/default.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from openmnglab.model.datamodel.interface import IOutputDataScheme
-from openmnglab.model.functions.interface import IFunctionDefinition
+from openmnglab.model.functions.interface import IFunctionDefinition, ProxyRet
 from openmnglab.planning.base import PlannerBase, check_input, ProxyData
 from openmnglab.planning.exceptions import PlanningError
 from openmnglab.model.planning.interface import IProxyData
 from openmnglab.model.planning.plan.interface import IStage, IPlannedData
 from openmnglab.util.hashing import Hash
-from openmnglab.util.iterables import ensure_iterable
+from openmnglab.util.iterables import ensure_iterable, unpack_sequence
 
 
 class Stage(IStage):
@@ -75,7 +75,7 @@ class PlannedData(IPlannedData):
 
 class DefaultPlanner(PlannerBase[Stage, PlannedData]):
 
-    def _add_function(self, function: IFunctionDefinition, *inp_data: PlannedData) -> tuple[IProxyData, ...]:
+    def _add_function(self, function: IFunctionDefinition[ProxyRet], *inp_data: PlannedData) -> ProxyRet:
         check_input(function.consumes, tuple(d.schema for d in inp_data))
         stage = Stage(function, *inp_data)
         if stage.calculated_hash in self._functions:
@@ -83,4 +83,4 @@ class DefaultPlanner(PlannerBase[Stage, PlannedData]):
         self._functions[stage.calculated_hash] = stage
         for prod in stage.data_out:
             self._data[prod.calculated_hash] = prod
-        return tuple(ProxyData.copy_from(o) for o in stage.data_out)
+        return unpack_sequence(tuple(ProxyData.copy_from(o) for o in stage.data_out))

--- a/openmnglab/planning/default.py
+++ b/openmnglab/planning/default.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from openmnglab.model.datamodel.interface import IOutputDataScheme
+from openmnglab.model.datamodel.interface import IOutputDataScheme, IInputDataScheme
 from openmnglab.model.functions.interface import IFunctionDefinition, ProxyRet
 from openmnglab.planning.base import PlannerBase, check_input, ProxyData
 from openmnglab.planning.exceptions import PlanningError

--- a/openmnglab/util/iterables.py
+++ b/openmnglab/util/iterables.py
@@ -5,22 +5,24 @@ T = TypeVar('T')
 def ensure_sequence(inp: Iterable[T] | T | None, type: Type[T], sequence_constructor: Callable[[Iterable[T]], Sequence[T]] = tuple) -> Sequence[T]:
     """Ensures that the input is a sequence.
 
-    Run checks:
-
-        1. :param:`inp` is ``None``: returns an empty tuple
-        2. :param:`inp` is an instace of :param:`type`: returns a tuple with :param:`inp` as sole element
-        3. :param:`inp` implements type ``Sequence``: return :param:`inp` without modification
-        4. Attempts to convert :param:`inp` to a ``Sequence`` by invoking :param:`sequence_constructor`
-
-    ..seealso::
+    .. seealso::
         :func:`ensure_iterable` for a varaint of this function which will return an interable
 
-    ..seealso::
+    .. seealso::
         :func:`unpack_sequence` for the inverse operation
 
+    Run checks:
+
+        1. ``inp`` is ``None``: returns an empty tuple
+        2. ``inp`` is an instace of ``type``: returns a tuple with ``inp`` as sole element
+        3. ``inp`` implements type ``Sequence``: return ``inp`` without modification
+        4. Attempts to convert ``inp`` to a ``Sequence`` by invoking ``sequence_constructor``
+
+
+
     :param inp: Value to convert to a sequence
-    :param type: Type of the value(s) passed to :param:`inp`
-    :param sequence_constructor: Callable used to convert :param:`inp` to a ``Sequence``, defaults to ``tuple``.
+    :param type: Type of the value(s) passed to ``inp``
+    :param sequence_constructor: Callable used to convert ``inp`` to a ``Sequence``, defaults to ``tuple``.
     :return: A sequence of values
     """
     if inp is None:
@@ -35,30 +37,27 @@ def ensure_sequence(inp: Iterable[T] | T | None, type: Type[T], sequence_constru
 def ensure_iterable(inp: Iterable[T] | T | None, type: Type[T]) -> Iterable[T]:
     """Ensures that the input is an iterable of the given type.
 
-    ..warning::
-        Only works if :param:`inp` is either ``None``, of type :param:`type` or an iterable of said type (see checks)
+    .. warning::
+        Only works if ``inp`` is either ``None``, of type ``type`` or an iterable of said type (see checks)
 
+    .. seealso::
+        :func:`ensure_sequence` for a varaint of this function which will ensure a sequence
+        (including automatic conversion from iterable to tuple)
+
+    .. seealso::
+        :func:`unpack_sequence` for the inverse operation for sequences
 
 
     performs the following checks:
 
-        1. :param:`inp` is ``None``: returns an empty tuple
-        2. :param:`inp` is an instace of :param:`type`: returns a tuple with :param:`inp` as sole element
-        3. return :param:`inp` without modification
-
-    ..seealso::
-        :func:`ensure_sequence` for a varaint of this function which will ensure a sequence
-        (including automatic conversion from iterable to tuple)
-
-    ..seealso::
-        :func:`unpack_sequence` for the inverse operation for sequences
+        1. ``inp`` is ``None``: returns an empty tuple
+        2. ``inp`` is an instace of ``type``: returns a tuple with ``inp`` as sole element
+        3. return ``inp`` without modification
 
 
-
-
-    :param inp: Iterable, a single item of type :param:`type` or ``None``
-    :param type: Base type of data in :param:`inp`
-    :return: An iterable of  element(s) from :param:`inp` or an empty tuple if :param:`inp`is ``None``
+    :param inp: Iterable, a single item of type ``type`` or ``None``
+    :param type: Base type of data in ``inp``
+    :return: An iterable of  element(s) from ``inp`` or an empty tuple if ``inp`` is ``None``
     """
     if inp is None:
         return tuple()
@@ -70,16 +69,16 @@ def ensure_iterable(inp: Iterable[T] | T | None, type: Type[T]) -> Iterable[T]:
 
 def unpack_sequence(inp: Sequence[T]) -> Sequence[T] | T | None:
     """Unpacks a sequence, based on the following conditions:
-
-        1. :param:`inp` has no items: return ``None``
-        2. :param:`inp` has one item: return that item
-        3. :param:`inp` has more items: return :param:`inp`
-
-    ..seealso::
+    .. seealso::
         :func:`ensure_iterable` for the inverse operation
 
+        1. ``inp`` has no items: return ``None``
+        2. ``inp`` has one item: return that item
+        3. ``inp`` has more items: return ``inp``
+
+
     :param inp: A sequence of items
-    :return: ``None`` if :param:`inp` is empty, the single value of :param:`inp` or :param:`inp` if it contains more than one item
+    :return: ``None`` if ``inp`` is empty, the single value of ``inp`` or ``inp`` if it contains more than one item
     """
     if len(inp) == 0:
         return None

--- a/openmnglab/util/iterables.py
+++ b/openmnglab/util/iterables.py
@@ -1,14 +1,16 @@
-from typing import TypeVar, Type, Iterable, Literal
+from typing import TypeVar, Type, Iterable, Sequence
 
 T = TypeVar('T')
 
 
-def ensure_iterable(inp:  Iterable[T] | T | None, type: Type[T]) -> Iterable[T]:
+def ensure_iterable(inp: Iterable[T] | T | None, type: Type[T]) -> Iterable[T]:
     """
     Ensures that the input is an iterable of the given type.
 
     ..warning::
         Only works if :param:`inp` is either ``None``, of type :param:`type` or an iterable of said type (see checks)
+
+
 
     performs the following checks:
 
@@ -16,14 +18,38 @@ def ensure_iterable(inp:  Iterable[T] | T | None, type: Type[T]) -> Iterable[T]:
         2. :param:`inp` is an instace of :param:`type`: returns a tuple with :param:`inp` as sole element
         3. return :param:`inp` without modification
 
+    ..seealso::
+        :func:`unpack_sequence` for the inverse operation for sequences
 
-    :param inp:
-    :param type:
-    :return:
+
+    :param inp: Iterable, a single item of type :param:`type` or ``None``
+    :param type: Base type of data in :param:`inp`
+    :return: An iterable of  element(s) from :param:`inp` or an empty tuple if :param:`inp`is ``None``
     """
     if inp is None:
         return tuple()
     elif isinstance(inp, type):
         return (inp,)
+    else:
+        return inp
+
+
+def unpack_sequence(inp: Sequence[T]) -> Sequence[T] | T | None:
+    """ Unpacks a sequence, based on the following conditions:
+
+        1. :param:`inp` has no items: return ``None``
+        2. :param:`inp` has one item: return that item
+        3. :param:`inp` has more items: return :param:`inp`
+
+    ..seealso::
+        :func:`ensure_iterable` for the inverse operation
+
+    :param inp: A sequence of items
+    :return: ``None`` if :param:`inp` is empty, the single value of :param:`inp` or :param:`inp` if it contains more than one item
+    """
+    if len(inp) == 0:
+        return None
+    elif len(inp) == 1:
+        return inp[0]
     else:
         return inp

--- a/openmnglab/util/iterables.py
+++ b/openmnglab/util/iterables.py
@@ -1,11 +1,39 @@
-from typing import TypeVar, Type, Iterable, Sequence
+from typing import TypeVar, Type, Iterable, Sequence, Callable
 
 T = TypeVar('T')
 
+def ensure_sequence(inp: Iterable[T] | T | None, type: Type[T], sequence_constructor: Callable[[Iterable[T]], Sequence[T]] = tuple) -> Sequence[T]:
+    """Ensures that the input is a sequence.
+
+    Run checks:
+
+        1. :param:`inp` is ``None``: returns an empty tuple
+        2. :param:`inp` is an instace of :param:`type`: returns a tuple with :param:`inp` as sole element
+        3. :param:`inp` implements type ``Sequence``: return :param:`inp` without modification
+        4. Attempts to convert :param:`inp` to a ``Sequence`` by invoking :param:`sequence_constructor`
+
+    ..seealso::
+        :func:`ensure_iterable` for a varaint of this function which will return an interable
+
+    ..seealso::
+        :func:`unpack_sequence` for the inverse operation
+
+    :param inp: Value to convert to a sequence
+    :param type: Type of the value(s) passed to :param:`inp`
+    :param sequence_constructor: Callable used to convert :param:`inp` to a ``Sequence``, defaults to ``tuple``.
+    :return: A sequence of values
+    """
+    if inp is None:
+        return tuple()
+    elif isinstance(inp, type):
+        return (inp,)
+    elif isinstance(inp, Sequence):
+        return inp
+    else:
+        return sequence_constructor(inp)
 
 def ensure_iterable(inp: Iterable[T] | T | None, type: Type[T]) -> Iterable[T]:
-    """
-    Ensures that the input is an iterable of the given type.
+    """Ensures that the input is an iterable of the given type.
 
     ..warning::
         Only works if :param:`inp` is either ``None``, of type :param:`type` or an iterable of said type (see checks)
@@ -19,7 +47,13 @@ def ensure_iterable(inp: Iterable[T] | T | None, type: Type[T]) -> Iterable[T]:
         3. return :param:`inp` without modification
 
     ..seealso::
+        :func:`ensure_sequence` for a varaint of this function which will ensure a sequence
+        (including automatic conversion from iterable to tuple)
+
+    ..seealso::
         :func:`unpack_sequence` for the inverse operation for sequences
+
+
 
 
     :param inp: Iterable, a single item of type :param:`type` or ``None``
@@ -35,7 +69,7 @@ def ensure_iterable(inp: Iterable[T] | T | None, type: Type[T]) -> Iterable[T]:
 
 
 def unpack_sequence(inp: Sequence[T]) -> Sequence[T] | T | None:
-    """ Unpacks a sequence, based on the following conditions:
+    """Unpacks a sequence, based on the following conditions:
 
         1. :param:`inp` has no items: return ``None``
         2. :param:`inp` has one item: return that item

--- a/openmnglab/util/iterables.py
+++ b/openmnglab/util/iterables.py
@@ -72,9 +72,9 @@ def unpack_sequence(inp: Sequence[T]) -> Sequence[T] | T | None:
     .. seealso::
         :func:`ensure_iterable` for the inverse operation
 
-        1. ``inp`` has no items: return ``None``
-        2. ``inp`` has one item: return that item
-        3. ``inp`` has more items: return ``inp``
+    1. ``inp`` has no items: return ``None``
+    2. ``inp`` has one item: return that item
+    3. ``inp`` has more items: return ``inp``
 
 
     :param inp: A sequence of items

--- a/openmnglab/util/iterables.py
+++ b/openmnglab/util/iterables.py
@@ -1,0 +1,29 @@
+from typing import TypeVar, Type, Iterable, Literal
+
+T = TypeVar('T')
+
+
+def ensure_iterable(inp:  Iterable[T] | T | None, type: Type[T]) -> Iterable[T]:
+    """
+    Ensures that the input is an iterable of the given type.
+
+    ..warning::
+        Only works if :param:`inp` is either ``None``, of type :param:`type` or an iterable of said type (see checks)
+
+    performs the following checks:
+
+        1. :param:`inp` is ``None``: returns an empty tuple
+        2. :param:`inp` is an instace of :param:`type`: returns a tuple with :param:`inp` as sole element
+        3. return :param:`inp` without modification
+
+
+    :param inp:
+    :param type:
+    :return:
+    """
+    if inp is None:
+        return tuple()
+    elif isinstance(inp, type):
+        return (inp,)
+    else:
+        return inp

--- a/quickstart/quickstart.ipynb
+++ b/quickstart/quickstart.ipynb
@@ -186,8 +186,7 @@
    "source": [
     "## 4. Add more functions\n",
     "Now you know how to build and execute a plan and get the data from it. Let's add some more stages to the execution plan.\n",
-    "* To provide input to a normal stage, we pass the proxy data object as simple additional arguments after the function.\n",
-    "* When a function produces only one piece of data, it will still return a tuple. Remember to add the required ',' to properly unpack that tuple."
+    "* To provide input to a normal stage, we pass the proxy data object as simple additional arguments after the function."
    ],
    "metadata": {
     "collapsed": false
@@ -202,11 +201,11 @@
     "from openmnglab.functions import Windowing, IntervalData, WaveformPlot\n",
     "\n",
     "# create a window of +- 1.5 ms around the actionpotential timestamps. Pass a name for the resulting series.\n",
-    "ap_windows, = planner.add_stage(Windowing(-1.5 * pq.ms, 1.5 * pq.ms, \"ap windows\"), tracks)\n",
+    "ap_windows = planner.add_stage(Windowing(-1.5 * pq.ms, 1.5 * pq.ms, \"ap windows\"), tracks)\n",
     "# now we will extract the data of the windows and calculate their first and second derivatives. This requires the window inervals and the continuous recording\n",
-    "action_potentials, = planner.add_stage(IntervalData(0, 1, 2, derivative_base=pq.ms), ap_windows, continuous_recording)\n",
+    "action_potentials = planner.add_stage(IntervalData(0, 1, 2, derivative_base=pq.ms), ap_windows, continuous_recording)\n",
     "# next, plot the average waveforms of the data with their standard deviation:\n",
-    "action_potential_plots, = planner.add_stage(WaveformPlot(), action_potentials)\n"
+    "action_potential_plots = planner.add_stage(WaveformPlot(), action_potentials)\n"
    ],
    "metadata": {
     "collapsed": false,


### PR DESCRIPTION
- Most functions requiring a tuple return may now also return a single item or none (depending on the function)
- added 3 new functions in `util.iterables` for easy (un)packing of such returns
- changed all existing functions to make use of the changes
- adjusted quickstart documentations to include the changes