### PR TITLE
Quickstart: Don't create a new executor for extended flow

### DIFF
--- a/quickstart/quickstart.ipynb
+++ b/quickstart/quickstart.ipynb
@@ -221,7 +221,9 @@
    "cell_type": "markdown",
    "source": [
     "### 4.1 execute the plan (and the figure)\n",
-    "Executing the plan will calculate and stages and immediately plot the figure when matplotlib is configured using the IPython backend (i.e. when running in Jupyter)."
+    "Executing the plan will calculate and stages and immediately plot the figure when matplotlib is configured using the IPython backend (i.e. when running in Jupyter).\n",
+    "\n",
+    "We will re-use the same executor as before. As the previously calculated results of the plan are still present, they can be reused to calculate the new parts of the plan."
    ],
    "metadata": {
     "collapsed": false
@@ -241,8 +243,7 @@
     }
    ],
    "source": [
-    "executor = SingleThreadedExecutor(planner.get_plan())\n",
-    "executor.execute()"
+    "executor.execute(planner.get_plan())"
    ],
    "metadata": {
     "collapsed": false,


### PR DESCRIPTION
Don't create a new executor in the quickstart for running the extended flow (which head the old API running anyways)

* Re-uses the old executor
* Includes a short explanation for the caching behaviour of the executor