### PR TITLE
021 one-liner changes

### DIFF
--- a/openmnglab/datamodel/matplot/model.py
+++ b/openmnglab/datamodel/matplot/model.py
@@ -1,3 +1,5 @@
+import copy
+
 import matplotlib.pyplot as plt
 
 from openmnglab.model.datamodel.interface import IDataContainer, T_co, IDataSchema
@@ -13,7 +15,9 @@ class MatPlotLibContainer(IDataContainer[plt.Figure]):
         return self.figure
 
     def deep_copy(self) -> IDataContainer[T_co]:
-        raise NotImplementedError("deep copy cannot be implemented for matplotlib figures")
+        figure_deepcopy =  copy.deepcopy(self.figure)
+        return MatPlotLibContainer(figure_deepcopy)
+
 
 
 class MatPlotlibSchema(IDataSchema):
@@ -21,4 +25,4 @@ class MatPlotlibSchema(IDataSchema):
         return isinstance(data_container, MatPlotLibContainer) and data_container.data is not None
 
     def accepts(self, output_data_scheme: IDataSchema) -> bool:
-        return isinstance(output_data_scheme, MatPlotLibContainer)
+        return isinstance(output_data_scheme, MatPlotlibSchema)

--- a/openmnglab/functions/input/readers/funcs/dapsys_reader.py
+++ b/openmnglab/functions/input/readers/funcs/dapsys_reader.py
@@ -19,8 +19,8 @@ from openmnglab.util.dicts import get_and_incr
 DPS_STIMDEFS = "stimulus definitions"
 
 @njit
-def _kernel_offset_assign(target: np.array, calc_add, calc_mul, pos_offset, n):
-    for i in range(n):
+def _kernel_offset_assign(target: np.array, calc_add, calc_mul, pos_offset: int, num_points: int):
+    for i in range(num_points):
         target[pos_offset + i] = calc_add + i * calc_mul
 
 @njit
@@ -140,7 +140,7 @@ class DapsysReaderFunc(SourceFunctionBase):
         """Stores the next number for each label (see lbl_num)"""
         self._log.debug("reading stimuli")
         timestamp_to_stimid = dict()
-        """Maps the timestamp of the pulse to the trace that has triggered it"""
+        """Maps the timestamp of the pulse to the trace index that has triggered it"""
         for i, page in enumerate(
                 file.pages[page_id] for page_id in page_ids):
             page: TextPage
@@ -183,7 +183,6 @@ class DapsysReaderFunc(SourceFunctionBase):
             n = 0
             self._log.info(f"processing streams ({n_responses} responses total)")
             sorted_ids = np.sort(np.fromiter(idmap.keys(), dtype=float))
-
             for stream in streams:
                 track_labels.extend(stream.name for _ in range(len(stream.page_ids)))
                 sorted_idx_offset, sorted_ids_slice = 0, sorted_ids

--- a/openmnglab/functions/plot/funcs/waveforms.py
+++ b/openmnglab/functions/plot/funcs/waveforms.py
@@ -74,8 +74,7 @@ class WaveformPlotFunc(FunctionBase):
     def _plot_rel(self, **lineplot_kwargs) -> plt.Figure:
         facet: sns.FacetGrid
         facet = sns.relplot(data=self.data, x=self.time_col, y=self.column, palette=self.colors, hue=self.track_index,
-                            row=self.row,
-                            col=self.col, kind="line", **lineplot_kwargs)
+                            row=self.row,col=self.col,  kind="line", **lineplot_kwargs)
         for axs_row in facet.axes:
             if axs_row[0].get_ylabel() != '':
                 axs_row[0].set_ylabel(f"{self.column} [{self.data_container.units[self.column].dimensionality.latex}]")
@@ -90,9 +89,10 @@ class WaveformPlotFunc(FunctionBase):
         return self._plot_line(**plot_kwargs)
 
     def _plot_avg(self) -> plt.Figure:
+        args = dict(errorbar="sd")
         if self._relplot:
-            return self._plot_rel()
-        return self._plot_line(errorbar="sd")
+            return self._plot_rel(**args)
+        return self._plot_line(**args)
 
     def _plot_overlap(self) -> plt.Figure:
         universal_kwargs = dict(estimator=None, units=self.stim_idx, alpha=self.alpha)

--- a/openmnglab/functions/plot/waveforms.py
+++ b/openmnglab/functions/plot/waveforms.py
@@ -76,6 +76,8 @@ class WaveformPlot(StaticFunctionDefinitionBase[IDataReference[plt.Figure]]):
             h.dict(self.fig_args, fail=False)
         if self.row is not None:
             h.str(self.row)
+        if self.col is not None:
+            h.str(self.col)
         if self.theme is not None:
             h.dynamic(self.theme.context, fail=False)
             h.dynamic(self.theme.style, fail=False)
@@ -97,7 +99,7 @@ class WaveformPlot(StaticFunctionDefinitionBase[IDataReference[plt.Figure]]):
 
     def new_function(self) -> WaveformPlotFunc:
         return WaveformPlotFunc(mode=self.mode, selector=self.selector, column=self.column, fig_args=self.fig_args,
-                                alpha=self.alpha, row=self.row, theme=self.theme, col=self.col, color_dict=self.col,
+                                alpha=self.alpha, row=self.row, theme=self.theme, col=self.col, color_dict=self.color_dict,
                                 time_col=self.time_col, stim_idx=self.stim_idx, **self.sns_args)
 
     @property

--- a/openmnglab/planning/default.py
+++ b/openmnglab/planning/default.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
 from openmnglab.model.datamodel.interface import IDataSchema
 from openmnglab.model.functions.interface import IFunctionDefinition, ProxyRet
 from openmnglab.model.planning.plan.interface import IStage, IVirtualData
@@ -76,6 +78,7 @@ class VirtualData(IVirtualData):
 class DefaultPlanner(PlannerBase[Stage, VirtualData]):
 
     def _add_function(self, function: IFunctionDefinition[ProxyRet], *inp_data: VirtualData) -> ProxyRet:
+        function = deepcopy(function)
         check_input(function.slot_acceptors, tuple(d.schema for d in inp_data))
         stage = Stage(function, *inp_data)
         if stage.planning_id in self._functions:


### PR DESCRIPTION
Some one-liner changes:

*` WaveformPlots`:
  * include `col` parameter when computing configuration hash
  * add errorbar for avg plots
 
*` DefaultPlanner` copies function-definitions, as defined in contract
* `MatplotlibContainer` implements deepcopy, as it stores a figure, which apparently can be deep-copied.
* readability improvements in dapsys implementation