### PR TITLE
Refactor names of "IntervalData" and "Windows"

### DIFF
--- a/openmnglab/functions/__init__.py
+++ b/openmnglab/functions/__init__.py
@@ -3,4 +3,4 @@ from openmnglab.functions.plot.waveforms import WaveformPlot, WaveformPlotMode
 from openmnglab.functions.processing.interval_data import IntervalData
 from openmnglab.functions.processing.spdf_components import SPDFComponents
 from openmnglab.functions.processing.spdf_features import SPDFFeatures
-from openmnglab.functions.processing.windowing import Windowing
+from openmnglab.functions.processing.static_intervals import StaticIntervals

--- a/openmnglab/functions/__init__.py
+++ b/openmnglab/functions/__init__.py
@@ -1,6 +1,6 @@
 from openmnglab.functions.input.readers.dapsys_reader import DapsysReader
 from openmnglab.functions.plot.waveforms import WaveformPlot, WaveformPlotMode
-from openmnglab.functions.processing.interval_data import IntervalData
+from openmnglab.functions.processing.windows import Windows
 from openmnglab.functions.processing.spdf_components import SPDFComponents
 from openmnglab.functions.processing.spdf_features import SPDFFeatures
 from openmnglab.functions.processing.static_intervals import StaticIntervals

--- a/openmnglab/functions/plot/funcs/waveforms.py
+++ b/openmnglab/functions/plot/funcs/waveforms.py
@@ -10,7 +10,7 @@ from openmnglab.datamodel.matplot.model import MatPlotLibContainer
 from openmnglab.datamodel.pandas.model import PandasContainer
 import openmnglab.datamodel.pandas.schemas as schema
 from openmnglab.functions.base import FunctionBase
-from openmnglab.functions.processing.funcs.interval_data import LEVEL_COLUMN
+from openmnglab.functions.processing.funcs.windows import LEVEL_COLUMN
 from openmnglab.util.seaborn import Theme
 
 

--- a/openmnglab/functions/plot/waveforms.py
+++ b/openmnglab/functions/plot/waveforms.py
@@ -9,7 +9,7 @@ from openmnglab.datamodel.matplot.model import MatPlotlibSchema
 from openmnglab.datamodel.pandas.model import PanderaSchemaAcceptor
 from openmnglab.functions.base import StaticFunctionDefinitionBase
 from openmnglab.functions.plot.funcs.waveforms import WaveformPlotMode, WaveformPlotFunc
-from openmnglab.functions.processing.funcs.interval_data import LEVEL_COLUMN
+from openmnglab.functions.processing.funcs.windows import LEVEL_COLUMN
 from openmnglab.model.planning.interface import IDataReference
 from openmnglab.util.hashing import HashBuilder
 from openmnglab.util.seaborn import Theme

--- a/openmnglab/functions/processing/__init__.py
+++ b/openmnglab/functions/processing/__init__.py
@@ -1,4 +1,4 @@
-from openmnglab.functions.processing.interval_data import IntervalData
+from openmnglab.functions.processing.windows import Windows
 from openmnglab.functions.processing.spdf_components import SPDFComponents
 from openmnglab.functions.processing.spdf_features import SPDFFeatures
 from openmnglab.functions.processing.static_intervals import StaticIntervals

--- a/openmnglab/functions/processing/__init__.py
+++ b/openmnglab/functions/processing/__init__.py
@@ -1,4 +1,4 @@
 from openmnglab.functions.processing.interval_data import IntervalData
 from openmnglab.functions.processing.spdf_components import SPDFComponents
 from openmnglab.functions.processing.spdf_features import SPDFFeatures
-from openmnglab.functions.processing.windowing import Windowing
+from openmnglab.functions.processing.static_intervals import StaticIntervals

--- a/openmnglab/functions/processing/funcs/spdf_components.py
+++ b/openmnglab/functions/processing/funcs/spdf_components.py
@@ -6,7 +6,7 @@ from pandas import DataFrame
 
 from openmnglab.datamodel.pandas.model import PandasContainer
 from openmnglab.functions.base import FunctionBase
-from openmnglab.functions.processing.funcs.interval_data import LEVEL_COLUMN
+from openmnglab.functions.processing.funcs.windows import LEVEL_COLUMN
 
 
 def get_zerocorssings(vals: np.ndarray) -> np.ndarray:

--- a/openmnglab/functions/processing/funcs/spdf_features.py
+++ b/openmnglab/functions/processing/funcs/spdf_features.py
@@ -8,7 +8,7 @@ from pandas import Series, DataFrame
 
 from openmnglab.datamodel.pandas.model import PandasContainer
 from openmnglab.functions.base import FunctionBase
-from openmnglab.functions.processing.funcs.interval_data import LEVEL_COLUMN
+from openmnglab.functions.processing.funcs.windows import LEVEL_COLUMN
 from openmnglab.functions.processing.funcs.spdf_components import SPDF_COMPONENTS
 from openmnglab.util.pandas import index_names
 

--- a/openmnglab/functions/processing/funcs/static_intervals.py
+++ b/openmnglab/functions/processing/funcs/static_intervals.py
@@ -11,7 +11,7 @@ from openmnglab.functions.helpers.general import get_index_quantities
 from openmnglab.functions.helpers.quantity_helpers import magnitudes, rescale_pq
 
 
-class WindowingFunc(FunctionBase):
+class StaticIntervalsFunc(FunctionBase):
     def __init__(self, lo: pq.Quantity, hi: pq.Quantity, name: str, closed="right"):
         assert (isinstance(lo, pq.Quantity))
         assert (isinstance(hi, pq.Quantity))
@@ -32,7 +32,7 @@ class WindowingFunc(FunctionBase):
         # window_series: Series = origin_series.transform(to_interval)
 
         if len(origin_series) > 0:
-            window_series: Series = origin_series.transform(to_interval)
+            interval_series: Series = origin_series.transform(to_interval)
         else:
             if isinstance(origin_series.index, pandas.MultiIndex):
                 idx = pandas.MultiIndex.from_arrays(
@@ -40,11 +40,11 @@ class WindowingFunc(FunctionBase):
                     names=[lvl.name for lvl in origin_series.index.levels])
             elif isinstance(origin_series.index, pandas.Index):
                 idx = pandas.Index(np.empty(0, dtype=origin_series.index.dtype), name=origin_series.index.name)
-            window_series = Series(data=[], dtype=IntervalDtype(), index=idx)
-        window_series.name = self._name
+            interval_series = Series(data=[], dtype=IntervalDtype(), index=idx)
+        interval_series.name = self._name
         q_dict = get_index_quantities(self._target_series_container)
-        q_dict[window_series.name] = series_quantity
-        return PandasContainer(window_series, q_dict)
+        q_dict[interval_series.name] = series_quantity
+        return PandasContainer(interval_series, q_dict)
 
     def set_input(self, series: PandasContainer[Series]):
         self._target_series_container = series

--- a/openmnglab/functions/processing/funcs/windows.py
+++ b/openmnglab/functions/processing/funcs/windows.py
@@ -67,7 +67,7 @@ def extend_multiindex(base: list[np.ndarray], ranges: np.ndarray):
     return multiidx
 
 
-class IntervalDataFunc(FunctionBase):
+class WindowsFunc(FunctionBase):
     def __init__(self, levels: tuple[int, ...],
                  derivatives: bool,
                  derivative_change: Optional[pq.Quantity], interval: Optional[float] = None, use_time_offsets=True):

--- a/openmnglab/functions/processing/spdf_components.py
+++ b/openmnglab/functions/processing/spdf_components.py
@@ -4,7 +4,7 @@ from pandas import DataFrame
 from openmnglab.datamodel.pandas.model import PanderaSchemaAcceptor, PandasDataSchema
 from openmnglab.functions.base import FunctionDefinitionBase
 from openmnglab.functions.processing.funcs.spdf_components import SPDFComponentsFunc, SPDF_COMPONENTS
-from openmnglab.functions.processing.interval_data import IntervalDataAcceptor
+from openmnglab.functions.processing.windows import WindowDataAcceptor
 from openmnglab.model.planning.interface import IDataReference
 
 
@@ -42,8 +42,8 @@ class SPDFComponents(FunctionDefinitionBase[IDataReference[DataFrame]]):
         return bytes()
 
     @property
-    def slot_acceptors(self) -> IntervalDataAcceptor:
-        return IntervalDataAcceptor(0, 1)
+    def slot_acceptors(self) -> WindowDataAcceptor:
+        return WindowDataAcceptor(0, 1)
 
     @staticmethod
     def output_for(diffs: PandasDataSchema[pa.DataFrameSchema]) -> SPDFComponentsDynamicSchema:

--- a/openmnglab/functions/processing/spdf_features.py
+++ b/openmnglab/functions/processing/spdf_features.py
@@ -5,7 +5,7 @@ from openmnglab.datamodel.pandas.model import PandasDataSchema, PanderaSchemaAcc
 from openmnglab.datamodel.pandas.verification import compare_index
 from openmnglab.functions.base import FunctionDefinitionBase
 from openmnglab.functions.processing.funcs.spdf_features import SPDF_FEATURES, FeatureFunc
-from openmnglab.functions.processing.interval_data import IntervalDataAcceptor, IntervalDataDynamicSchema
+from openmnglab.functions.processing.windows import WindowDataAcceptor, WindowDataDynamicSchema
 from openmnglab.functions.processing.spdf_components import SPDFComponentsDynamicSchema, \
     SPDFComponentsAcceptor
 from openmnglab.model.planning.interface import IDataReference
@@ -40,11 +40,11 @@ class SPDFFeatures(FunctionDefinitionBase[IDataReference[DataFrame]]):
         return bytes()
 
     @property
-    def slot_acceptors(self) -> tuple[SPDFComponentsAcceptor, IntervalDataAcceptor]:
-        return SPDFComponentsAcceptor(), IntervalDataAcceptor(0, 1, 2)
+    def slot_acceptors(self) -> tuple[SPDFComponentsAcceptor, WindowDataAcceptor]:
+        return SPDFComponentsAcceptor(), WindowDataAcceptor(0, 1, 2)
 
     def output_for(self, principle_compo: SPDFComponentsDynamicSchema,
-                   diffs: IntervalDataDynamicSchema) -> SPDFFeaturesDynamicSchema:
+                   diffs: WindowDataDynamicSchema) -> SPDFFeaturesDynamicSchema:
         compare_index(principle_compo.pandera_schema.index, pa.MultiIndex(diffs.pandera_schema.index.indexes[:-1]))
         return SPDFFeaturesDynamicSchema(principle_compo.pandera_schema.index)
 

--- a/openmnglab/functions/processing/static_intervals.py
+++ b/openmnglab/functions/processing/static_intervals.py
@@ -39,7 +39,7 @@ class DynamicIndexIntervalSchema(PandasDataSchema[SeriesSchema]):
 
 
 class StaticIntervals(FunctionDefinitionBase[IDataReference[DataFrame]]):
-    """Takes a set of values and transforms them based on a fixed window.
+    """Creates intervals based on a low and high offset
 
     In: series of numbers
 

--- a/openmnglab/functions/processing/static_intervals.py
+++ b/openmnglab/functions/processing/static_intervals.py
@@ -10,14 +10,14 @@ from pandera import SeriesSchema
 from openmnglab.datamodel.exceptions import DataSchemaCompatibilityError
 from openmnglab.datamodel.pandas.model import PandasDataSchema
 from openmnglab.functions.base import FunctionDefinitionBase
-from openmnglab.functions.processing.funcs.windowing import WindowingFunc
+from openmnglab.functions.processing.funcs.static_intervals import StaticIntervalsFunc
 from openmnglab.model.datamodel.interface import ISchemaAcceptor, IDataSchema
 from openmnglab.model.functions.interface import IFunction
 from openmnglab.model.planning.interface import IDataReference
 from openmnglab.util.hashing import HashBuilder
 
 
-class WindowingSchemaAcceptor(ISchemaAcceptor):
+class IntervalSchemaAcceptor(ISchemaAcceptor):
 
     def accepts(self, output_data_scheme: IDataSchema) -> bool:
         if not isinstance(output_data_scheme, PandasDataSchema):
@@ -38,7 +38,7 @@ class DynamicIndexIntervalSchema(PandasDataSchema[SeriesSchema]):
         return DynamicIndexIntervalSchema(SeriesSchema(IntervalDtype, index=inp.pandera_schema.index, name=name))
 
 
-class Windowing(FunctionDefinitionBase[IDataReference[DataFrame]]):
+class StaticIntervals(FunctionDefinitionBase[IDataReference[DataFrame]]):
     """Takes a set of values and transforms them based on a fixed window.
 
     In: series of numbers
@@ -74,12 +74,12 @@ class Windowing(FunctionDefinitionBase[IDataReference[DataFrame]]):
             .digest()
 
     @property
-    def slot_acceptors(self) -> WindowingSchemaAcceptor:
-        return WindowingSchemaAcceptor()
+    def slot_acceptors(self) -> IntervalSchemaAcceptor:
+        return IntervalSchemaAcceptor()
 
     def output_for(self, inp: PandasDataSchema) -> DynamicIndexIntervalSchema:
         assert isinstance(inp, PandasDataSchema)
         return DynamicIndexIntervalSchema.for_input(inp, self._name)
 
     def new_function(self) -> IFunction:
-        return WindowingFunc(self._lo, self._hi, self._name, closed=self._closed)
+        return StaticIntervalsFunc(self._lo, self._hi, self._name, closed=self._closed)

--- a/tests/e2e/test_dapsys_e2e.py
+++ b/tests/e2e/test_dapsys_e2e.py
@@ -14,7 +14,6 @@ import openmnglab.datamodel.pandas.schemas as schema
 
 
 class TestDapsysE2E:
-
     @pytest.fixture(scope='class')
     def planner(self) -> DefaultPlanner:
         return DefaultPlanner()
@@ -52,12 +51,12 @@ class TestDapsysE2E:
         return dapsys_data[4]
 
     @pytest.fixture(scope='class')
-    def window_intervals(self, planner, tracks):
+    def static_intervals(self, planner, tracks):
         return planner.add_stage(StaticIntervals(-2 * pq.ms, 3 * pq.ms, "spike_windows"), tracks)
 
     @pytest.fixture(scope='class')
-    def windows(self, planner, window_intervals, signal):
-        return planner.add_stage(IntervalData(0, 1, 2, derivative_base=pq.ms), window_intervals, signal)
+    def windows(self, planner, static_intervals, signal):
+        return planner.add_stage(IntervalData(0, 1, 2, derivative_base=pq.ms), static_intervals, signal)
 
     @pytest.fixture(scope='class')
     def spdf_components(self, planner, windows):

--- a/tests/e2e/test_dapsys_e2e.py
+++ b/tests/e2e/test_dapsys_e2e.py
@@ -7,7 +7,7 @@ import quantities as pq
 
 
 from openmnglab.execution import SingleThreadedExecutor
-from openmnglab.functions import DapsysReader, StaticIntervals, IntervalData, SPDFComponents, SPDFFeatures, WaveformPlot, \
+from openmnglab.functions import DapsysReader, StaticIntervals, Windows, SPDFComponents, SPDFFeatures, WaveformPlot, \
     WaveformPlotMode
 from openmnglab.planning import DefaultPlanner
 import openmnglab.datamodel.pandas.schemas as schema
@@ -56,7 +56,7 @@ class TestDapsysE2E:
 
     @pytest.fixture(scope='class')
     def windows(self, planner, static_intervals, signal):
-        return planner.add_stage(IntervalData(0, 1, 2, derivative_base=pq.ms), static_intervals, signal)
+        return planner.add_stage(Windows(0, 1, 2, derivative_base=pq.ms), static_intervals, signal)
 
     @pytest.fixture(scope='class')
     def spdf_components(self, planner, windows):

--- a/tests/e2e/test_dapsys_e2e.py
+++ b/tests/e2e/test_dapsys_e2e.py
@@ -7,7 +7,7 @@ import quantities as pq
 
 
 from openmnglab.execution import SingleThreadedExecutor
-from openmnglab.functions import DapsysReader, Windowing, IntervalData, SPDFComponents, SPDFFeatures, WaveformPlot, \
+from openmnglab.functions import DapsysReader, StaticIntervals, IntervalData, SPDFComponents, SPDFFeatures, WaveformPlot, \
     WaveformPlotMode
 from openmnglab.planning import DefaultPlanner
 import openmnglab.datamodel.pandas.schemas as schema
@@ -53,7 +53,7 @@ class TestDapsysE2E:
 
     @pytest.fixture(scope='class')
     def window_intervals(self, planner, tracks):
-        return planner.add_stage(Windowing(-2 * pq.ms, 3 * pq.ms, "spike_windows"), tracks)
+        return planner.add_stage(StaticIntervals(-2 * pq.ms, 3 * pq.ms, "spike_windows"), tracks)
 
     @pytest.fixture(scope='class')
     def windows(self, planner, window_intervals, signal):


### PR DESCRIPTION
Refactored names for more clarity, based on the following concept: An _interval_ is a (mathematical) interval. A _window_ is data corresponding to an interval.

* `Windows` is now `StaticIntervals`
* `IntervalData` is now `Windows`